### PR TITLE
change hex to uppercase before searching db

### DIFF
--- a/core/stats-interesting.go
+++ b/core/stats-interesting.go
@@ -25,7 +25,7 @@ func updateInterestingSeen(pg *postgres) {
 
 	for _, aircraft := range aircrafts {
 		aircraftsMap[strings.ToUpper(aircraft.Hex)] = aircraft
-		aircraftsHex = append(aircraftsHex, aircraft.Hex)
+		aircraftsHex = append(aircraftsHex, strings.ToUpper(aircraft.Hex))
 	}
 
 	query := `


### PR DESCRIPTION
This changes the icao hex to uppercase before searching the database. Without this it won't find any military, government, etc. planes unless the plane in question has an all-numeric ICAO.

With it, it now seems to be finding planes to populate these tables:
<img width="1279" height="920" alt="image" src="https://github.com/user-attachments/assets/b17be65b-27c7-4a67-85c5-1c0c965f87d3" />
