### PR TITLE
Compose file cleanup and addition of .env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+READSB_AIRCRAFT_JSON=http://yourhost:yourport/data/aircraft.json
+DB_HOST=skystats-db
+DB_PORT=5432
+DB_USER=user
+DB_PASSWORD=1234
+DB_NAME=skystats_db
+DOMESTIC_COUNTRY_ISO=US
+LAT=0.0000
+LON=0.0000
+RADIUS=500
+ABOVE_RADIUS=20
+TZ=Etc/UTC

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
         - DB_PASSWORD=${DB_PASSWORD}
         - DB_NAME=${DB_NAME}
         - PLANE_DB_URL=https://raw.githubusercontent.com/sdr-enthusiasts/plane-alert-db/refs/heads/main/plane-alert-db.csv
-        - IMAGE_DB_URL=https://raw.githubusercontent.com/sdr-enthusiasts/plane-alert-db/refs/heads/main/plane_images.csvi
+        - IMAGE_DB_URL=https://raw.githubusercontent.com/sdr-enthusiasts/plane-alert-db/refs/heads/main/plane_images.csv
         - TZ=${TZ}
       volumes:
         - ./scripts:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,34 +1,37 @@
 services:
-  app:
+  skystats-api:
     build: .
+    container_name: skystats-api
     ports:
       - "8080:8080"
     depends_on:
-      - db-init
+      - skystats-db-init
     environment:
       # Docker environment flag (used to skip daemonising the app when in Docker)
       - DOCKER_ENV=true
       # ADSB
-      - READSB_AIRCRAFT_JSON=
+      - READSB_AIRCRAFT_JSON=${READSB_AIRCRAFT_JSON}
       # PostgreSQL
-      - DB_HOST=skystats-db-docker
-      - DB_PORT=5432
-      - DB_USER=
-      - DB_PASSWORD=
-      - DB_NAME=skystats_db
+      - DB_HOST=${DB_HOST}
+      - DB_PORT=${DB_PORT}
+      - DB_USER=${DB_USER}
+      - DB_PASSWORD=${DB_PASSWORD}
+      - DB_NAME=${DB_NAME}
       # ADSB DB API
       - ADSB_DB_AIRCRAFT_ENDPOINT=https://api.adsbdb.com/v0/aircraft/
       - ADSB_DB_CALLSIGN_ENDPOINT=https://api.adsbdb.com/v0/callsign/
       # App
       - API_PORT=8080
-      - LATITUDE=
-      - LONGITUDE=
-      - RADIUS=
-      - ABOVE_RADIUS=20
-      - DOMESTIC_COUNTRY_ISO=
+      - LATITUDE=${LAT}
+      - LONGITUDE=${LON}
+      - RADIUS=${RADIUS}
+      - ABOVE_RADIUS=${ABOVE_RADIUS}
+      - DOMESTIC_COUNTRY_ISO=${DOMESTIC_COUNTRY_ISO}
+      - TZ=${TZ}
 
-  frontend:
+  skystats-web:
     image: node:20-alpine
+    container_name: skystats-web
     working_dir: /app
     ports:
       - "5173:5173"
@@ -38,22 +41,25 @@ services:
     environment:
       - NODE_ENV=development
       - DOCKER_ENV=true
+      - TZ=${TZ}
     command: sh -c "npm install && npm run dev -- --host 0.0.0.0"
     depends_on:
-      - app
+      - skystats-api
 
-  db-init:
+  skystats-db-init:
       image: python:3.11-slim
+      container_name: skystats-db-init
       depends_on:
-        - skystats-db-docker
+        - skystats-db
       environment:
-        - DB_HOST=skystats-db-docker
-        - DB_PORT=5432
-        - DB_USER=
-        - DB_PASSWORD=
-        - DB_NAME=skystats_db
+        - DB_HOST=${DB_HOST}
+        - DB_PORT=${DB_PORT}
+        - DB_USER=${DB_USER}
+        - DB_PASSWORD=${DB_PASSWORD}
+        - DB_NAME=${DB_NAME}
         - PLANE_DB_URL=https://raw.githubusercontent.com/sdr-enthusiasts/plane-alert-db/refs/heads/main/plane-alert-db.csv
-        - IMAGE_DB_URL=https://raw.githubusercontent.com/sdr-enthusiasts/plane-alert-db/refs/heads/main/plane_images.csv
+        - IMAGE_DB_URL=https://raw.githubusercontent.com/sdr-enthusiasts/plane-alert-db/refs/heads/main/plane_images.csvi
+        - TZ=${TZ}
       volumes:
         - ./scripts:/app
       working_dir: /app
@@ -63,15 +69,17 @@ services:
           python plane-alert-db.py
         "
       restart: "no"
-  
-  skystats-db-docker:
+
+  skystats-db:
     image: postgres:latest
+    container_name: skystats-db
     ports:
       - "5432:5432"
     environment:
-      - POSTGRES_USER=
-      - POSTGRES_PASSWORD=
-      - POSTGRES_DB=skystats_db
+      - POSTGRES_USER=${DB_USER}
+      - POSTGRES_PASSWORD=${DB_PASSWORD}
+      - POSTGRES_DB=${DB_NAME}
+      - TZ=${TZ}
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./scripts/schema.sql:/docker-entrypoint-initdb.d/schema.sql

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -8,7 +8,7 @@ export default defineConfig({
     proxy: {
       '/api': {
         target: process.env.NODE_ENV === 'development' && process.env.DOCKER_ENV ? 
-          'http://app:8080' : 'http://localhost:8080',
+          'http://skystats-api:8080' : 'http://localhost:8080',
         changeOrigin: true,
       }
     }


### PR DESCRIPTION
I've renamed the services to match their functions and added container_name variables for them. I've also added an example .env file for reference. This should help prevent typos in the multiple DB config entries in the compose, thereby avoiding possible queries that would result from typos. Modded the vite config to match.