### PR TITLE
example yml: pin postgres to major version 17

### DIFF
--- a/example.compose.yml
+++ b/example.compose.yml
@@ -25,7 +25,7 @@ services:
       - DOMESTIC_COUNTRY_ISO=${DOMESTIC_COUNTRY_ISO}
 
   skystats-db:
-    image: postgres:latest
+    image: postgres:17
     container_name: skystats-db
     environment:
       - POSTGRES_USER=${DB_USER}


### PR DESCRIPTION
version 18 has weird folder logic to mount the data until this is figured out, prevent issues by pinning to 17