### PR TITLE
fix: remove redundant indexes, tune autovacuum settings, optimise recent seen query

### DIFF
--- a/core/aircraft.go
+++ b/core/aircraft.go
@@ -96,6 +96,8 @@ func getAircraftsRecentlySeen(pg *postgres, nowEpoch float64, aircrafts []Aircra
 		hexValues = append(hexValues, a.Hex)
 	}
 
+	recentThreshold := int(nowEpoch) - 600
+
 	query := `
 		SELECT DISTINCT ON (hex)
 			id,
@@ -110,11 +112,12 @@ func getAircraftsRecentlySeen(pg *postgres, nowEpoch float64, aircrafts []Aircra
 			ias,
 			tas
 		FROM aircraft_data
-		WHERE hex = ANY($1::text[])
+		WHERE hex = ANY($1::text[]) 
+			AND last_seen_epoch > $2
 		ORDER BY hex, last_seen DESC;
-    `
+	`
 
-	rows, err := pg.db.Query(context.Background(), query, hexValues)
+	rows, err := pg.db.Query(context.Background(), query, hexValues, recentThreshold)
 	if err != nil {
 		fmt.Println("getAircraftsRecentlySeen() - Error querying db: ", err)
 		return nil
@@ -138,9 +141,6 @@ func getAircraftsRecentlySeen(pg *postgres, nowEpoch float64, aircrafts []Aircra
 
 		if err != nil {
 			fmt.Println("getAircraftsRecentlySeen() - Error scanning rows: ", err)
-			continue
-		}
-		if nowEpoch-existingAircraft.LastSeenEpoch > 600 {
 			continue
 		}
 

--- a/migrations/000005_change_aircraft_data_idx.down.sql
+++ b/migrations/000005_change_aircraft_data_idx.down.sql
@@ -1,0 +1,12 @@
+-- Recreate the old indexes that were dropped
+CREATE INDEX IF NOT EXISTS idx_aircraft_data_hex_last_seen
+ON aircraft_data (hex, last_seen_epoch DESC);
+
+CREATE INDEX IF NOT EXISTS aircraft_data_hex
+ON aircraft_data (hex);
+
+-- Reset autovacuum settings to defaults
+ALTER TABLE aircraft_data RESET (
+  autovacuum_vacuum_scale_factor,
+  autovacuum_vacuum_cost_delay
+);

--- a/migrations/000005_change_aircraft_data_idx.up.sql
+++ b/migrations/000005_change_aircraft_data_idx.up.sql
@@ -1,0 +1,11 @@
+-- Lower the threshold for when autovacuum runs, but increase the sleep time
+ALTER TABLE aircraft_data SET (
+  autovacuum_vacuum_scale_factor = 0.1,
+  autovacuum_vacuum_cost_delay = 10
+);
+
+-- Drop previous bloated / rarely used index
+DROP INDEX IF EXISTS idx_aircraft_data_hex_last_seen;
+
+-- Drop unused index
+DROP INDEX IF EXISTS aircraft_data_hex;


### PR DESCRIPTION
* Fix: Remove `idx_aircraft_data_hex_last_seen` and `aircraft_data_hex` indexes (resolves https://github.com/tomcarman/skystats/issues/84)
* Fix: Tune autovacuum settings to reduce index bloat
* Fix: Optimise the "recently seen" query