### PR TITLE
feat: add user setting to disable plane-alert-db tags in Interesting Aircraft modal

### DIFF
--- a/migrations/000006_add_user_setting_for_tags.down.sql
+++ b/migrations/000006_add_user_setting_for_tags.down.sql
@@ -1,0 +1,1 @@
+DELETE FROM user_settings WHERE setting_key = 'enable_planealertdb_tags';

--- a/migrations/000006_add_user_setting_for_tags.up.sql
+++ b/migrations/000006_add_user_setting_for_tags.up.sql
@@ -1,0 +1,2 @@
+INSERT INTO user_settings (setting_key, setting_value, description) VALUES
+    ('disable_planealertdb_tags', 'false', 'Disable plane alert database tags');

--- a/web/src/components/InterestingAircraft.svelte
+++ b/web/src/components/InterestingAircraft.svelte
@@ -1,6 +1,6 @@
 <script>
     import { onMount, onDestroy } from 'svelte'
-    import { refreshInterestingData } from '../stores/settings';
+    import { settings, refreshInterestingData } from '../stores/settings';
 
     export let endpoint;
     export let title;
@@ -67,6 +67,8 @@
         fetchData();
     }
 
+    $: disableTags = $settings['disable_planealertdb_tags']?.setting_value === 'true';
+
 </script>
 
 <div>
@@ -130,17 +132,19 @@
         {#if selectedAircraft}
             <div class="flex items-center justify-between mb-2">
                 <h3 class="text-lg font-bold">{selectedAircraft.registration} - {selectedAircraft.type}</h3>
-                <div class="flex gap-2">
-                    {#if selectedAircraft.tag1}
-                        <div class="badge badge-accent text-white">{selectedAircraft.tag1}</div>
-                    {/if}
-                     {#if selectedAircraft.tag2}
-                        <div class="badge badge-accent text-white">{selectedAircraft.tag2}</div>
-                    {/if}
-                    {#if selectedAircraft.tag3}
-                        <div class="badge badge-accent text-white">{selectedAircraft.tag3}</div>
-                    {/if}
-                </div>
+                {#if disableTags === false}
+                    <div class="flex gap-2">
+                        {#if selectedAircraft.tag1}
+                            <div class="badge badge-accent text-white">{selectedAircraft.tag1}</div>
+                        {/if}
+                        {#if selectedAircraft.tag2}
+                            <div class="badge badge-accent text-white">{selectedAircraft.tag2}</div>
+                        {/if}
+                        {#if selectedAircraft.tag3}
+                            <div class="badge badge-accent text-white">{selectedAircraft.tag3}</div>
+                        {/if}
+                    </div>
+                {/if}
             </div>
             <p class="text-sm text-gray-600 mb-4">{selectedAircraft.operator} {#if selectedAircraft.flight} - {selectedAircraft.flight} {/if}</p>
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/web/src/components/Settings.svelte
+++ b/web/src/components/Settings.svelte
@@ -10,6 +10,7 @@
     let routeTableLimit;
     let interestingTableLimit;
     let recordHolderTableLimit;
+    let disablePlaneAlertDbTags;
     let settingsChanged = false;
     let version = { version: '...', commit: '...', date: '...' };
 
@@ -28,6 +29,9 @@
         if ($settings.record_holder_table_limit) {
             recordHolderTableLimit = parseInt($settings.record_holder_table_limit.setting_value);
         }
+        if ($settings.disable_planealertdb_tags) {
+            disablePlaneAlertDbTags = $settings.disable_planealertdb_tags.setting_value === 'true';
+        }
     }
 
     function handleSettingChange() {
@@ -45,7 +49,8 @@
         const updates = {
             route_table_limit: routeTableLimit.toString(),
             interesting_table_limit: interestingTableLimit.toString(),
-            record_holder_table_limit: recordHolderTableLimit.toString()
+            record_holder_table_limit: recordHolderTableLimit.toString(),
+            disable_planealertdb_tags: disablePlaneAlertDbTags.toString()
         };
 
         const success = await settings.save(updates);
@@ -105,7 +110,8 @@
                         <h4 class="text-lg font-semibold mb-6">Display Settings</h4>
 
                         <form id="display-settings-form" class="space-y-6">
-                            <!-- Route Table Limit -->
+                            
+                            <!-- Route Table Display Settings -->
                             <div>
                                 <p class="text-xl font-extralight tracking-wider mb-4">Route Information</p>
                                 <p class="text-m text-base-content/70 mb-2">
@@ -124,7 +130,10 @@
                                 />
                                 <span class="ml-2 text-sm text-base-content/70">(1-100)</span>
                             </div>
-                            <!-- Interesting Table Limit -->
+
+                            <!-- Interesting Table Display Settings -->
+
+                            <!-- Interesting Table Display Settings: Table Limit -->
                             <div>
                                 <p class="text-xl font-extralight tracking-wider mb-4">Interesting Aircraft</p>
                                 <p class="text-m text-base-content/70 mb-2">
@@ -143,7 +152,25 @@
                                 />
                                 <span class="ml-2 text-sm text-base-content/70">(1-100)</span>
                             </div>
-                            <!-- Record Holder Table Limit -->
+
+                            <!-- Interesting Table Display Settings: Disable Tags -->
+                            <div>
+                                <!-- <p class="text-xl font-extralight tracking-wider mb-4">PlaneAlertDB Tags</p> -->
+                                <label class="flex items-center gap-3">
+                                    <input
+                                        type="checkbox"
+                                        bind:checked={disablePlaneAlertDbTags}
+                                        on:change={handleSettingChange}
+                                        class="checkbox"
+                                    />
+                                    <span class="text-m text-base-content/70">
+                                        Disable <a href="https://github.com/sdr-enthusiasts/plane-alert-db?tab=readme-ov-file#description-of-categories" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-primary transition-colors">plane-alert-db</a> tags in modal
+                                    </span>
+                                </label>
+                            </div>
+
+
+                            <!-- Record Holder Display Settings -->
                             <div>
                                 <p class="text-xl font-extralight tracking-wider mb-4">Record Holders</p>
                                 <p class="text-m text-base-content/70 mb-2">


### PR DESCRIPTION

* Add user setting to disable the "tags" from plane-alert-db that show in the Interesting Aircraft modal
* Resolves: https://github.com/tomcarman/skystats/issues/94

<img width="1095" height="665" alt="Image" src="https://github.com/user-attachments/assets/1c3393ab-9d70-41d3-b58f-572a37e09fdd" />

<img width="960" height="437" alt="Image" src="https://github.com/user-attachments/assets/51568e21-0896-4068-b4cf-3a3ba56388cf" />

