### PR TITLE
feat: add in-memory cache for recently seen aircraft

### DIFF
--- a/core/aircraft.go
+++ b/core/aircraft.go
@@ -92,10 +92,23 @@ func (pg *postgres) updateDatabase(nowEpoch float64, aircrafts []Aircraft) {
 func getAircraftsRecentlySeen(pg *postgres, nowEpoch float64, aircrafts []Aircraft) map[string]*Aircraft {
 
 	existingAircrafts := make(map[string]*Aircraft)
+	now := time.Now()
+	newExpiry := now.Add(10 * time.Minute)
 
-	var hexValues []string
+	var uncachedHexes []string
+
 	for _, a := range aircrafts {
-		hexValues = append(hexValues, a.Hex)
+		entry, ok := pg.recentAircraftCache[a.Hex]
+		if ok && now.Before(entry.expiresAt) {
+			entry.expiresAt = newExpiry
+			existingAircrafts[a.Hex] = &entry.aircraft
+		} else {
+			uncachedHexes = append(uncachedHexes, a.Hex)
+		}
+	}
+
+	if len(uncachedHexes) == 0 {
+		return existingAircrafts
 	}
 
 	recentThreshold := int(nowEpoch) - 600
@@ -114,12 +127,12 @@ func getAircraftsRecentlySeen(pg *postgres, nowEpoch float64, aircrafts []Aircra
 			ias,
 			tas
 		FROM aircraft_data
-		WHERE hex = ANY($1::text[]) 
+		WHERE hex = ANY($1::text[])
 			AND last_seen_epoch > $2
 		ORDER BY hex, last_seen DESC;
 	`
 
-	rows, err := pg.db.Query(context.Background(), query, hexValues, recentThreshold)
+	rows, err := pg.db.Query(context.Background(), query, uncachedHexes, recentThreshold)
 	if err != nil {
 		fmt.Println("getAircraftsRecentlySeen() - Error querying db: ", err)
 		return nil
@@ -127,26 +140,30 @@ func getAircraftsRecentlySeen(pg *postgres, nowEpoch float64, aircrafts []Aircra
 	defer rows.Close()
 
 	for rows.Next() {
-		var existingAircraft Aircraft
+		var a Aircraft
 		err := rows.Scan(
-			&existingAircraft.Id,
-			&existingAircraft.Hex,
-			&existingAircraft.LastSeenEpoch,
-			&existingAircraft.LastSeenLat,
-			&existingAircraft.LastSeenLon,
-			&existingAircraft.LastSeenDistance,
-			&existingAircraft.AltBaro,
-			&existingAircraft.AltGeom,
-			&existingAircraft.Gs,
-			&existingAircraft.Ias,
-			&existingAircraft.Tas)
+			&a.Id,
+			&a.Hex,
+			&a.LastSeenEpoch,
+			&a.LastSeenLat,
+			&a.LastSeenLon,
+			&a.LastSeenDistance,
+			&a.AltBaro,
+			&a.AltGeom,
+			&a.Gs,
+			&a.Ias,
+			&a.Tas)
 
 		if err != nil {
 			log.Error().Err(err).Msg("getAircraftsRecentlySeen() - error scanning rows")
 			continue
 		}
 
-		existingAircrafts[existingAircraft.Hex] = &existingAircraft
+		pg.recentAircraftCache[a.Hex] = &aircraftCacheEntry{
+			aircraft:  a,
+			expiresAt: newExpiry,
+		}
+		existingAircrafts[a.Hex] = &pg.recentAircraftCache[a.Hex].aircraft
 	}
 
 	return existingAircrafts

--- a/core/db-connector.go
+++ b/core/db-connector.go
@@ -4,13 +4,20 @@ import (
 	"context"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog/log"
 )
 
+type aircraftCacheEntry struct {
+	aircraft  Aircraft
+	expiresAt time.Time
+}
+
 type postgres struct {
-	db *pgxpool.Pool
+	db                 *pgxpool.Pool
+	recentAircraftCache map[string]*aircraftCacheEntry
 }
 
 var (
@@ -25,7 +32,10 @@ func NewPG(ctx context.Context, connString string) (*postgres, error) {
 			log.Error().Err(err).Msg("Unable to connect to database")
 		}
 
-		pgInstance = &postgres{db}
+		pgInstance = &postgres{
+			db:                  db,
+			recentAircraftCache: make(map[string]*aircraftCacheEntry),
+		}
 	})
 
 	return pgInstance, nil


### PR DESCRIPTION
* Previously, the query in `getAircraftRecentlySeen()` was running every tick/2s, and querying every hex currently in range.
* As the main aircraft_data table has grown, aircraft have been seen many times, so lots of rows were getting loaded, before finally filtered again to get the most recent occurrence of each hex.
* This was leading to huge CPU spikes - slow query, being done every 2s.
* It was also a bit stupid, because the app knows what aircraft its recently seen, as they were in the last aircraft.json. Only "new" aircraft need to be checked (in case they had been dropped / re-entered).
* The recently seen aircraft are now cached in memory - this means the query only runs when "new" aircraft are seen, and it only runs against those particular hexes (making it faster)
* tldr; recently seen query runs less and faster.