### PR TITLE
fix: log fatal error when the API server fails to start

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -139,7 +139,9 @@ func (s *APIServer) Start() {
 	r.Static("/static", "../web")
 	r.StaticFile("/", "../web/index.html")
 
-	r.Run("0.0.0.0:" + s.port)
+	if err := r.Run("0.0.0.0:" + s.port); err != nil {
+		log.Fatal().Err(err).Msg("Failed to start API server on port " + s.port)
+	}
 
 }
 func (s *APIServer) getFlightsSeenMetrics(c *gin.Context) {


### PR DESCRIPTION
`APIServer.Start()` discards the error returned by `r.Run()`, and it's launched from a goroutine that nobody watches (`go func() { apiServer.Start() }()` in `core.go`). The result: if the listener fails to start, skystats keeps running with no API and no log line at all — the ticker loops carry on so the process looks perfectly healthy.

This is easy to hit in practice. I found it running skystats in Kubernetes: with service links enabled, a Service named `api` in the same namespace makes Kubernetes inject `API_PORT=tcp://<cluster-ip>:80` into the pod, skystats picks it up as its listen port, `r.Run()` fails to parse the address — and the failure is completely silent. Debugging that took far longer than it should have; a single log line would have pointed straight at the cause. Same story for a port that's already in use, or any other malformed `API_PORT`.

The fix checks the error and logs it via zerolog at fatal level (exiting like the other startup failures in `core.go` do), consistent with the codebase's existing `log.Fatal().Err(err).Msg(...)` pattern. Failing fast seems right here: a skystats with no API is doing no useful work, and a loud crash gets noticed and restarted by Docker/K8s, while a silent half-alive process does not.