### PR TITLE
Make Record Holders rows clickable

### DIFF
--- a/web/src/components/MotionStats.svelte
+++ b/web/src/components/MotionStats.svelte
@@ -11,6 +11,12 @@
     let data = [];
     let loading = true;
     let error = null;
+    let selectedAircraft = null;
+    let selectedAircraftImage = null;
+    let imageLoading = true;
+
+    // Unique modal id per table (fastest/slowest/highest/lowest)
+    const modalId = 'motion-modal-' + endpoint.replace(/[^a-zA-Z0-9]/g, '-');
 
     async function fetchData() {
 
@@ -27,6 +33,48 @@
         } finally {
             loading = false;
         }
+    }
+
+    async function getImage(aircraft) {
+        if (!aircraft?.hex) {
+            return null;
+        }
+
+        try {
+            const response = await fetch(`https://api.planespotters.net/pub/photos/hex/${aircraft.hex}`);
+            if (!response.ok) {
+                return null;
+            }
+            const result = await response.json();
+            const photo = result.photos?.[0];
+            if (!photo) {
+                return null;
+            }
+            return {
+                url_photo: photo.thumbnail_large?.src,
+                url_photo_photographer: photo.photographer,
+                url_photo_link: photo.link
+            };
+        } catch (err) {
+            console.error("Error fetching image:", err);
+            return null;
+        }
+    }
+
+    async function showAircraftModal(aircraft) {
+        selectedAircraft = aircraft;
+        selectedAircraftImage = null;
+        imageLoading = true;
+        // @ts-ignore
+        document.getElementById(modalId).showModal();
+
+        selectedAircraftImage = await getImage(aircraft);
+        imageLoading = false;
+    }
+
+    function closeModal() {
+        selectedAircraft = null;
+        selectedAircraftImage = null;
     }
 
     onMount(() => {
@@ -63,7 +111,7 @@
                     {#if icon}
                         <div class="w-8 h-8 rounded-lg flex items-center justify-center">
                             <svelte:component this={icon} class="w-6 h-6 text-primary" />
-                        </div> 
+                        </div>
                     {/if}
                     <h2 class="text-2xl font-extralight tracking-wider">{title}</h2>
                     </div>
@@ -78,7 +126,7 @@
                         </thead>
                         <tbody>
                             {#each data as aircraft}
-                            <tr>
+                            <tr class="hover:bg-base-300 cursor-pointer" on:click={() => showAircraftModal(aircraft)}>
                                 {#each columns as column}
                                     <td class={column.class || ''}>
                                         {#if column.formatter}
@@ -97,3 +145,64 @@
         </div>
     </div>
 </div>
+
+<!--modal-->
+<dialog id={modalId} class="modal" on:close={closeModal}>
+    <div class="modal-box max-w-2xl">
+        {#if selectedAircraft}
+            <div class="flex items-center justify-between mb-1">
+                <h3 class="text-lg font-bold">{selectedAircraft.registration || 'Unknown'} - {selectedAircraft.type || ''}</h3>
+                {#if selectedAircraft.hex}
+                    <p class="text-sm uppercase tracking-wider font-mono">{selectedAircraft.hex}</p>
+                {/if}
+            </div>
+            {#if selectedAircraft.flight}
+                <p class="text-sm text-gray-600 mb-4">{selectedAircraft.flight}</p>
+            {/if}
+
+            <!-- photo -->
+            {#if imageLoading}
+                <div class="skeleton h-64 w-full rounded-lg mb-4"></div>
+            {:else if selectedAircraftImage?.url_photo}
+                <div class="relative mb-4">
+                    <a href={selectedAircraftImage.url_photo_link} target="_blank" rel="noopener noreferrer">
+                        <img
+                            src={selectedAircraftImage.url_photo}
+                            alt="{selectedAircraft.registration}"
+                            class="w-full h-auto rounded-lg"
+                        />
+                    </a>
+                    {#if selectedAircraftImage.url_photo_photographer}
+                        <span class="absolute bottom-1 right-2 text-xs text-white opacity-80">© {selectedAircraftImage.url_photo_photographer}</span>
+                    {/if}
+                </div>
+            {:else}
+                <p class="text-center text-gray-500 py-8">No photo available for this aircraft</p>
+            {/if}
+
+            <!-- details -->
+            <div class="grid grid-cols-2 gap-x-6 gap-y-1">
+                {#each columns as column}
+                    <div class="flex justify-between border-b border-base-200 py-1">
+                        <span class="text-xs uppercase tracking-wider text-gray-500">{column.header}</span>
+                        <span class="text-sm text-right">
+                            {#if column.formatter}
+                                {@html column.formatter(selectedAircraft[column.field])}
+                            {:else}
+                                {selectedAircraft[column.field] || '-'}
+                            {/if}
+                        </span>
+                    </div>
+                {/each}
+            </div>
+        {/if}
+        <div class="modal-action">
+            <form method="dialog">
+                <button class="btn">Close</button>
+            </form>
+        </div>
+    </div>
+    <form method="dialog" class="modal-backdrop">
+        <button>close</button>
+    </form>
+</dialog>


### PR DESCRIPTION
The Interesting tables let you click a row to see aircraft details, but the Record Holders tables (Fastest/Slowest/Highest/Lowest) didn't. This adds the same behaviour — clicking a row opens a modal with the aircraft photo and its record details.

Frontend-only, in the shared `MotionStats.svelte` component. Photos are fetched by hex from planespotters (same as the "Above Me" modal).

<img width="1256" height="1428" alt="image" src="https://github.com/user-attachments/assets/dc915af5-1f65-4ac9-9cc1-282c55bdedcd" />

